### PR TITLE
[Feature] Support modify sequenceName

### DIFF
--- a/ktorm-ksp-api/src/main/kotlin/org/ktorm/ksp/api/Table.kt
+++ b/ktorm-ksp-api/src/main/kotlin/org/ktorm/ksp/api/Table.kt
@@ -72,5 +72,11 @@ public annotation class Table(
     /**
      * Specifies to ignore properties that do not generate column definitions.
      */
-    val ignoreColumns: Array<String> = []
+    val ignoreColumns: Array<String> = [],
+
+    /**
+     * The sequence name，By default, the first character lowercase of the [tableClassName], and the value
+     * will not be an empty string.
+     */
+    val sequenceName: String = "",
 )

--- a/ktorm-ksp-codegen/src/main/kotlin/org/ktorm/ksp/codegen/DefaultTableCodeGenerator.kt
+++ b/ktorm-ksp-codegen/src/main/kotlin/org/ktorm/ksp/codegen/DefaultTableCodeGenerator.kt
@@ -319,7 +319,11 @@ public class SequencePropertyGenerator : TopLevelPropertyGenerator {
         val table = context.table
         val sequenceOf = MemberName("org.ktorm.entity", "sequenceOf", true)
         val tableClassName = table.tableClassName.simpleName
-        val sequenceName = tableClassName.substring(0, 1).lowercase() + tableClassName.substring(1)
+
+        val sequenceName = table.sequenceName.ifEmpty {
+            tableClassName.substring(0, 1).lowercase() + tableClassName.substring(1)
+        }
+
         val entitySequence = EntitySequence::class.asClassName()
         // EntitySequence<E, T>
         val sequenceType = entitySequence.parameterizedBy(table.entityClassName, table.tableClassName)

--- a/ktorm-ksp-codegen/src/main/kotlin/org/ktorm/ksp/codegen/DefaultTableCodeGenerator.kt
+++ b/ktorm-ksp-codegen/src/main/kotlin/org/ktorm/ksp/codegen/DefaultTableCodeGenerator.kt
@@ -319,11 +319,9 @@ public class SequencePropertyGenerator : TopLevelPropertyGenerator {
         val table = context.table
         val sequenceOf = MemberName("org.ktorm.entity", "sequenceOf", true)
         val tableClassName = table.tableClassName.simpleName
-
         val sequenceName = table.sequenceName.ifEmpty {
             tableClassName.substring(0, 1).lowercase() + tableClassName.substring(1)
         }
-
         val entitySequence = EntitySequence::class.asClassName()
         // EntitySequence<E, T>
         val sequenceType = entitySequence.parameterizedBy(table.entityClassName, table.tableClassName)

--- a/ktorm-ksp-codegen/src/main/kotlin/org/ktorm/ksp/codegen/definition/TableDefinition.kt
+++ b/ktorm-ksp-codegen/src/main/kotlin/org/ktorm/ksp/codegen/definition/TableDefinition.kt
@@ -41,6 +41,13 @@ public data class TableDefinition(
     val tableClassName: ClassName,
 
     /**
+     * The sequence name，By default, the first character lowercase of the [tableClassName], and the value
+     * will not be an empty string.
+     */
+    val sequenceName: String,
+
+
+    /**
      * The Table alias, Corresponding to the [org.ktorm.ksp.api.Table.alias] property, may be an empty string.
      */
     val alias: String,

--- a/ktorm-ksp-compiler/src/main/kotlin/org/ktorm/ksp/compiler/KtormProcessorProvider.kt
+++ b/ktorm-ksp-compiler/src/main/kotlin/org/ktorm/ksp/compiler/KtormProcessorProvider.kt
@@ -51,7 +51,7 @@ public class KtormProcessorProvider : SymbolProcessorProvider {
 }
 
 public class KtormProcessor(
-    private val environment: SymbolProcessorEnvironment
+    private val environment: SymbolProcessorEnvironment,
 ) : SymbolProcessor {
     private val logger = environment.logger
 
@@ -204,7 +204,7 @@ public class KtormProcessor(
 
     public inner class EntityVisitor(
         private val tableDefinitions: MutableList<TableDefinition>,
-        private val entityTableMap: MutableMap<ClassName, ClassName>
+        private val entityTableMap: MutableMap<ClassName, ClassName>,
     ) : KSVisitorVoid() {
 
         @OptIn(KspExperimental::class, KotlinPoetKspPreview::class)
@@ -222,6 +222,7 @@ public class KtormProcessor(
                             ?: error("wrong entity class declaration: ${entityClassName.canonicalName}, Entity of interface type must inherit [${entityQualifiedName}]")
                         KtormEntityType.ENTITY_INTERFACE
                     }
+
                     ClassKind.CLASS -> KtormEntityType.ANY_KIND_CLASS
                     else -> error("wrong entity class declaration: ${entityClassName.canonicalName}, classKind must to be Interface or Class")
                 }
@@ -237,6 +238,7 @@ public class KtormProcessor(
                 val tableDef = TableDefinition(
                     tableName,
                     tableClassName,
+                    table.sequenceName,
                     table.alias,
                     table.catalog,
                     table.schema,
@@ -314,12 +316,15 @@ public class KtormProcessor(
                         this.endsWith("ch") -> {
                     return this + "es"
                 }
+
                 this.endsWith("y") -> {
                     return this.substring(0, this.length - 1) + "ies"
                 }
+
                 this.endsWith("o") -> {
                     return this + "es"
                 }
+
                 else -> {
                     return this + "s"
                 }

--- a/ktorm-ksp-compiler/src/test/kotlin/org/ktorm/ksp/compiler/test/KtormKspTest.kt
+++ b/ktorm-ksp-compiler/src/test/kotlin/org/ktorm/ksp/compiler/test/KtormKspTest.kt
@@ -830,8 +830,8 @@ public class KtormKspTest {
                 import org.ktorm.entity.EntitySequence
                 import org.ktorm.ksp.api.*
                 import java.time.LocalDate
-                // modify sequenceName  
-                @Table(sequenceName = "aUsers")
+
+                @Table
                 data class User(
                     @PrimaryKey
                     var id: Int,
@@ -853,7 +853,7 @@ public class KtormKspTest {
 
                 object TestBridge {
                     fun getUsers(database:Database): EntitySequence<User,Users> {
-                        return database.aUsers
+                        return database.users
                     }
                     fun getEmployees(database: Database): EntitySequence<Employee,Employees> {
                         return database.employees
@@ -879,6 +879,51 @@ public class KtormKspTest {
             assertThat(
                 employees.toList().toString()
             ).isEqualTo("[Employee{id=1, name=vince, job=engineer, hireDate=2018-01-01}, Employee{id=2, name=marry, job=trainee, hireDate=2019-01-01}, Employee{id=3, name=tom, job=director, hireDate=2018-01-01}, Employee{id=4, name=penny, job=assistant, hireDate=2019-01-01}]")
+        }
+    }
+
+    @Test
+    public fun `custom sequence name `() {
+        val (result1, result2) = twiceCompile(
+            SourceFile.kotlin(
+                "source.kt",
+                """
+                import org.ktorm.database.Database
+                import org.ktorm.entity.Entity
+                import org.ktorm.entity.EntitySequence
+                import org.ktorm.ksp.api.*
+                import java.time.LocalDate
+
+                @Table(sequenceName = "aUsers")
+                data class User(
+                    @PrimaryKey
+                    var id: Int,
+                    var username: String,
+                    var age: Int
+                )
+
+                @KtormKspConfig(namingStrategy = CamelCaseToSnakeCaseNamingStrategy::class)
+                class KtormConfig
+
+                object TestBridge {
+                    fun getUsers(database:Database): EntitySequence<User,Users> {
+                        return database.aUsers
+                    }
+                }
+                """,
+            )
+        )
+        assertThat(result1.exitCode).isEqualTo(ExitCode.OK)
+        assertThat(result2.exitCode).isEqualTo(ExitCode.OK)
+        val bridgeClass = result2.classLoader.loadClass("TestBridge")
+        val bridge = bridgeClass.kotlin.objectInstance
+        useDatabase { database ->
+            val users =
+                bridgeClass.kotlin.functions.first { it.name == "getUsers" }
+                    .call(bridge, database) as EntitySequence<*, *>
+            assertThat(users.sourceTable.tableName).isEqualTo("user")
+            val toList = users.toList()
+            assertThat(toList.toString()).isEqualTo("[User(id=1, username=jack, age=20), User(id=2, username=lucy, age=22), User(id=3, username=mike, age=22)]")
         }
     }
 

--- a/ktorm-ksp-compiler/src/test/kotlin/org/ktorm/ksp/compiler/test/KtormKspTest.kt
+++ b/ktorm-ksp-compiler/src/test/kotlin/org/ktorm/ksp/compiler/test/KtormKspTest.kt
@@ -830,8 +830,8 @@ public class KtormKspTest {
                 import org.ktorm.entity.EntitySequence
                 import org.ktorm.ksp.api.*
                 import java.time.LocalDate
-                    
-                @Table
+                // modify sequenceName  
+                @Table(sequenceName = "aUsers")
                 data class User(
                     @PrimaryKey
                     var id: Int,
@@ -853,7 +853,7 @@ public class KtormKspTest {
 
                 object TestBridge {
                     fun getUsers(database:Database): EntitySequence<User,Users> {
-                        return database.users
+                        return database.aUsers
                     }
                     fun getEmployees(database: Database): EntitySequence<Employee,Employees> {
                         return database.employees
@@ -881,6 +881,7 @@ public class KtormKspTest {
             ).isEqualTo("[Employee{id=1, name=vince, job=engineer, hireDate=2018-01-01}, Employee{id=2, name=marry, job=trainee, hireDate=2019-01-01}, Employee{id=3, name=tom, job=director, hireDate=2018-01-01}, Employee{id=4, name=penny, job=assistant, hireDate=2019-01-01}]")
         }
     }
+
 
     @Test
     public fun `sequence add function`() {

--- a/ktorm-ksp-compiler/src/test/resources/init-data.sql
+++ b/ktorm-ksp-compiler/src/test/resources/init-data.sql
@@ -2,7 +2,7 @@ create table "user"
 (
     "id"       int          not null primary key auto_increment,
     "username" varchar(128) not null,
-    "age"      int          not null,
+    "age"      int          not null
 );
 
 

--- a/ktorm-ksp-ext/ktorm-ksp-ext-sequence-batch/src/test/resources/init-data.sql
+++ b/ktorm-ksp-ext/ktorm-ksp-ext-sequence-batch/src/test/resources/init-data.sql
@@ -2,7 +2,7 @@ create table "user"
 (
     "id"       int          not null primary key auto_increment,
     "username" varchar(128) not null,
-    "age"      int          not null,
+    "age"      int          not null
 );
 
 


### PR DESCRIPTION
现在当 table 名字首字母定义为小写的时候 (有时候希望table类名和数据库的表名完全一致，代码看起来更好理解) ， 代码生成会报错


```kotlin
// 这段代码生成出来会报错
@Table(tableClassName = "t_user")
data class User(
    @PrimaryKey
    var id: Int,
    var username: String,
    var age: Int
)
```

支持自定义 sequence 属性名字可以就可以修复这一点



